### PR TITLE
Make cobertura report use relative path as filename

### DIFF
--- a/lib/cobertura/index.js
+++ b/lib/cobertura/index.js
@@ -2,6 +2,7 @@
  Copyright 2012-2015, Yahoo Inc.
  Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
  */
+var path = require('path');
 function CoberturaReport(opts) {
     this.cw = null;
     this.xml = null;
@@ -87,7 +88,7 @@ CoberturaReport.prototype.onDetail = function (node) {
 
     this.xml.openTag('class', {
         name: asClassName(node),
-        filename: node.getQualifiedName(),
+        filename: path.relative(this.projectRoot, fileCoverage.path),
         'line-rate': metrics.lines.pct / 100.0,
         'branch-rate': metrics.branches.pct / 100.0
     });


### PR DESCRIPTION
Current cobertura report generated with filename as filename only without any path info. This change it to use relative path based on projectRoot, so jenkins could display the file content properly
