### PR TITLE
convert sourceText to string if it's a Buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ istanbul-reports
 
 [![Build Status](https://travis-ci.org/istanbuljs/istanbul-reports.svg?branch=master)](https://travis-ci.org/istanbuljs/istanbul-reports)
 
+![Dependencies](https://david-dm.org/tkuminecz/istanbul-reports.svg)
+
 * node.getRelativeName
 
 * context.getSource(filePath)

--- a/lib/html/annotator.js
+++ b/lib/html/annotator.js
@@ -171,8 +171,9 @@ function annotateSourceCode(fileCoverage, sourceStore) {
         lineCoverageArray;
     try {
         var sourceText = sourceStore.getSource(fileCoverage.path);
-        if (sourceText instanceof Buffer)
+        if (sourceText instanceof Buffer) {
             sourceText = Buffer.toString();
+        }
         var code = sourceText.split(/(?:\r?\n)|\r/),
             count = 0,
             structured = code.map(function (str) {

--- a/lib/html/annotator.js
+++ b/lib/html/annotator.js
@@ -170,8 +170,10 @@ function annotateSourceCode(fileCoverage, sourceStore) {
     var codeArray,
         lineCoverageArray;
     try {
-        var sourceText = sourceStore.getSource(fileCoverage.path),
-            code = sourceText.split(/(?:\r?\n)|\r/),
+        var sourceText = sourceStore.getSource(fileCoverage.path);
+        if (sourceText instanceof Buffer)
+            sourceText = Buffer.toString();
+        var code = sourceText.split(/(?:\r?\n)|\r/),
             count = 0,
             structured = code.map(function (str) {
                 count += 1;


### PR DESCRIPTION
My files in the HTML coverage reports looked like:

```
sourceText.split is not a function
TypeError: sourceText.split is not a function
    at Object.annotateSourceCode (/Users/Tim/studio/estee-lauder-facecharts-api/node_modules/istanbul-reports/lib/html/annotator.js:174:31)
    ...
```

Turns out `sourceText` was as Buffer, not a string.
