### PR TITLE
Teamcity reporter modified to send proper coverage values

### DIFF
--- a/lib/teamcity/index.js
+++ b/lib/teamcity/index.js
@@ -22,26 +22,21 @@ TeamcityReport.prototype.onStart = function (node, context) {
     cw.println('');
     cw.println('##teamcity[blockOpened name=\''+ this.blockName +'\']');
 
-
     //Statements Covered
-    cw.println(lineForKey(metrics.statements.covered, 'CodeCoverageAbsSCovered'));
-    cw.println(lineForKey(metrics.statements.total, 'CodeCoverageAbsSTotal'));
-    cw.println(lineForKey(metrics.statements.pct, 'CodeCoverageS'));
+    cw.println(lineForKey(metrics.statements.covered, 'CodeCoverageAbsBCovered'));
+    cw.println(lineForKey(metrics.statements.total, 'CodeCoverageAbsBTotal'));
 
     //Branches Covered
-    cw.println(lineForKey(metrics.branches.covered, 'CodeCoverageAbsBCovered'));
-    cw.println(lineForKey(metrics.branches.total, 'CodeCoverageAbsBTotal'));
-    cw.println(lineForKey(metrics.branches.pct, 'CodeCoverageB'));
+    cw.println(lineForKey(metrics.branches.covered, 'CodeCoverageAbsRCovered'));
+    cw.println(lineForKey(metrics.branches.total, 'CodeCoverageAbsRTotal'));
 
     //Functions Covered
     cw.println(lineForKey(metrics.functions.covered, 'CodeCoverageAbsMCovered'));
     cw.println(lineForKey(metrics.functions.total, 'CodeCoverageAbsMTotal'));
-    cw.println(lineForKey(metrics.functions.pct, 'CodeCoverageM'));
 
     //Lines Covered
     cw.println(lineForKey(metrics.lines.covered, 'CodeCoverageAbsLCovered'));
     cw.println(lineForKey(metrics.lines.total, 'CodeCoverageAbsLTotal'));
-    cw.println(lineForKey(metrics.lines.pct, 'CodeCoverageL'));
 
     cw.println('##teamcity[blockClosed name=\''+ this.blockName +'\']');
     cw.close();


### PR DESCRIPTION
With these modifications we have consistency with: https://github.com/gotwarlost/istanbul/pull/680
And we are compatible with TeamCity 9.x / TeamCity 10.x

Changes:
- Modified Statement coverage metric name CodeCoverageAbsBCovered, CodeCoverageAbsBTotal
- Modified Branch coverage metric name CodeCoverageAbsRCovered, CodeCoverageAbsRCovered
- Removed CodeCoverageS, CodeCoverageB, CodeCoverageM, CodeCoverageL as TeamCity will not use them.

TeamCity documentation states this:

> You should not publish values CodeCoverageB, CodeCoverageL, CodeCoverageM, CodeCoverageC standing for block/line/method/class coverage percentage. TeamCity will calculate these values using their absolute parts. E.g. CodeCoverageL will be calculated as CodeCoverageAbsLCovered divided by CodeCoverageAbsLTotal. You could publish these values but in this case they will lack decimal parts and will not be useful.

Statisctic metrics in TeamCity 10.x : https://confluence.jetbrains.com/display/TCD10/Custom+Chart#CustomChart-DefaultStatisticsValuesProvidedbyTeamCity

Statistic metrics in TeamCity 9.x:
https://confluence.jetbrains.com/display/TCD9/Custom+Chart#CustomChart-DefaultStatisticsValuesProvidedbyTeamCity
