### PR TITLE
Skip branch if meta does not exist

### DIFF
--- a/lib/html/annotator.js
+++ b/lib/html/annotator.js
@@ -130,7 +130,7 @@ function annotateBranches(fileCoverage, structuredText) {
         // only highlight if partial branches are missing or if there is a
         // single uncovered branch.
         if (sumCount > 0 || (sumCount === 0 && branchArray.length === 1)) {
-            for (i = 0; i < branchArray.length; i += 1) {
+            for (i = 0; i < branchArray.length && i < metaArray.length; i += 1) {
                 count = branchArray[i];
                 meta = metaArray[i];
                 type = count > 0 ? 'yes' : 'no';


### PR DESCRIPTION
This commit protects against slightly wrong metadata generated from the `babel-plugin-rewire` module (see [this issue](https://github.com/speedskater/babel-plugin-rewire/issues/165)).
