### PR TITLE
Preserve escape char of json key path on Windows

### DIFF
--- a/lib/json/index.js
+++ b/lib/json/index.js
@@ -24,9 +24,8 @@ JsonReport.prototype.onDetail = function (node) {
     } else {
         cw.write(",");
     }
-    cw.write('"');
-    cw.write(key);
-    cw.write('": ');
+    cw.write(JSON.stringify(key));
+    cw.write(': ');
     cw.write(JSON.stringify(fc));
     cw.println("");
 };


### PR DESCRIPTION
This PR updates behavior of `jsonReporter` for writing its key.

While coverage JSON takes path to file its key of coverage data, json reporter directly write key into file. This causes problem on windows machines since its path contains escape chars for backslash, makes stored  JSON is not valid and can't be parsed directly. In this pr, `stringify` key as well to preserve escape chars on windows. This does not affect on non-windows system.

**before**
![screen shot 2016-10-14 at 11 53 09](https://cloud.githubusercontent.com/assets/1210596/19399216/3e40bba0-9205-11e6-9222-1664c8c70713.png)

**after**
![screen shot 2016-10-14 at 11 56 00](https://cloud.githubusercontent.com/assets/1210596/19399222/4509f8e8-9205-11e6-9c24-7bff46f7fe6b.png)
