### PR TITLE
fix(windows): preserve escape char of json-summary key path

### DIFF
--- a/lib/json-summary/index.js
+++ b/lib/json-summary/index.js
@@ -22,9 +22,8 @@ JsonSummaryReport.prototype.writeSummary = function (filePath, sc) {
     } else {
         cw.write(",");
     }
-    cw.write('"');
-    cw.write(filePath);
-    cw.write('": ');
+    cw.write(JSON.stringify(filePath));
+    cw.write(': ');
     cw.write(JSON.stringify(sc));
     cw.println("");
 };


### PR DESCRIPTION
This was fixed in the [json reporter](https://github.com/istanbuljs/istanbul-reports/commit/4e5266e5edb0deadc75fe3eab3b7e3ef31f9af31), but not the json-summary reporter.