### PR TITLE
Fixes for Clover reporter

### DIFF
--- a/lib/clover/index.js
+++ b/lib/clover/index.js
@@ -88,8 +88,7 @@ CloverReport.prototype.writeRootStats = function (node, context) {
         attrs[k] = treeStats[k];
     });
 
-    this.xml.openTag('metrics', attrs);
-
+    this.xml.inlineTag('metrics', attrs);
 };
 
 CloverReport.prototype.writeMetrics = function (metrics) {

--- a/lib/clover/index.js
+++ b/lib/clover/index.js
@@ -55,35 +55,37 @@ CloverReport.prototype.getTreeStats = function (node, context) {
 };
 
 CloverReport.prototype.writeRootStats = function (node, context) {
-
-    var metrics = node.getCoverageSummary(),
-        attrs = {
-            statements: metrics.lines.total,
-            coveredstatements: metrics.lines.covered,
-            conditionals: metrics.branches.total,
-            coveredconditionals: metrics.branches.covered,
-            methods: metrics.functions.total,
-            coveredmethods: metrics.functions.covered,
-            elements: metrics.lines.total + metrics.branches.total + metrics.functions.total,
-            coveredelements: metrics.lines.covered + metrics.branches.covered + metrics.functions.covered,
-            complexity: 0,
-            loc: metrics.lines.total,
-            ncloc: metrics.lines.total // what? copied as-is from old report
-        },
-        treeStats;
+    var nowTimestamp = +Date.now();
 
     this.cw.println('<?xml version="1.0" encoding="UTF-8"?>');
     this.xml.openTag('coverage', {
-        generated: Date.now().toString(),
+        generated: nowTimestamp,
         clover: '3.2.0'
     });
 
     this.xml.openTag('project', {
-        timestamp: Date.now().toString(),
+        timestamp: nowTimestamp,
         name: 'All files',
     });
 
-    treeStats = this.getTreeStats(node, context);
+    var metrics = node.getCoverageSummary();
+    var attrs = {
+        statements: metrics.statements.total,
+        coveredstatements: metrics.statements.covered,
+        conditionals: metrics.branches.total,
+        coveredconditionals: metrics.branches.covered,
+        methods: metrics.functions.total,
+        coveredmethods: metrics.functions.covered,
+        elements: metrics.statements.total + metrics.branches.total + metrics.functions.total,
+        coveredelements: metrics.statements.covered + metrics.branches.covered + metrics.functions.covered,
+        complexity: 0,
+        // 'lines' is derived from 'statements', so it does not contain comments
+        ncloc: metrics.lines.total,
+        // to be correct here, lines included comments would need to be included
+        loc: metrics.lines.total
+    };
+    var treeStats = this.getTreeStats(node, context);
+
     Object.keys(treeStats).forEach(function (k) {
         attrs[k] = treeStats[k];
     });
@@ -93,8 +95,8 @@ CloverReport.prototype.writeRootStats = function (node, context) {
 
 CloverReport.prototype.writeMetrics = function (metrics) {
     this.xml.inlineTag('metrics', {
-        statements: metrics.lines.total,
-        coveredstatements: metrics.lines.covered,
+        statements: metrics.statements.total,
+        coveredstatements: metrics.statements.covered,
         conditionals: metrics.branches.total,
         coveredconditionals: metrics.branches.covered,
         methods: metrics.functions.total,
@@ -159,5 +161,3 @@ CloverReport.prototype.onDetail = function (node) {
 };
 
 module.exports = CloverReport;
-
-


### PR DESCRIPTION
After switching from gotwarlost/instanbul, we noticed two major problems in Clover reports:

* The unclosed ``<metrics />`` tag prevents Jenkins' plugin from showing package details
* The number of reported statements differs from the HTML report. It turned out that's because Clover reportee used lines instead of statements.