### PR TITLE
List available reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,28 @@ istanbul-reports
 [![Greenkeeper badge](https://badges.greenkeeper.io/istanbuljs/istanbul-reports.svg)](https://greenkeeper.io/)
 [![Build Status](https://travis-ci.org/istanbuljs/istanbul-reports.svg?branch=master)](https://travis-ci.org/istanbuljs/istanbul-reports)
 
-* node.getRelativeName
 
+## Reporters
+
+- clover
+- cobertura
+- html
+- json-summary
+- json
+- lcov
+- lcovonly
+- none
+- teamcity
+- text-lcov
+- text-summary
+- text
+
+
+## Development
+
+These are common methods used in the reporters:
+
+* node.getRelativeName
 * context.getSource(filePath)
 * context.classForPercent(type, percent)
 * context.console.colorize(str, class)


### PR DESCRIPTION
Running `nyc --help` links to this repo for a list of available reporters. That list was missing, so here's the bare minimum to satisfy anyone's curiosity.